### PR TITLE
Fix incorrect exit codes for "ls" and "lastlog"

### DIFF
--- a/src/scriptherder.py
+++ b/src/scriptherder.py
@@ -1386,6 +1386,8 @@ if __name__ == "__main__":
         progname = os.path.basename(sys.argv[0])
         args = parse_args(_defaults)
         res = main(progname, args=args)
+        if isinstance(res, bool):
+            sys.exit(int(not res))
         if isinstance(res, int):
             sys.exit(res)
         if res:


### PR DESCRIPTION
ls always returns True, and since `isinstance(True, int)` is true it always returns exit code 1.

if lastlog finds a log to display it fails with exit code 1, otherwise it prints an error message and returns exit code 0.