### PR TITLE
check: add --exclude to skip named jobs from catch-all check

### DIFF
--- a/src/scriptherder.py
+++ b/src/scriptherder.py
@@ -489,6 +489,9 @@ class JobsList:
                             "Skipping {!r} not matching {!r} (file {!s})".format(job.name, args.names, filename)
                         )
                         continue
+                if hasattr(args, "exclude") and args.exclude and job.name in args.exclude:
+                    logger.debug("Excluding {!r} (file {!s})".format(job.name, filename))
+                    continue
                 jobs.append(job)
         # Sort jobs, oldest first
         self.jobs = sorted(jobs, key=lambda x: x.start_time if x.start_time is not None else 0)
@@ -515,6 +518,9 @@ class JobsList:
                         "Skipping not-running {!r} not matching {!r} (file {!s})".format(name, self._args.names, this)
                     )
                     continue
+            if hasattr(self._args, "exclude") and self._args.exclude and name in self._args.exclude:
+                self._logger.debug("Excluding not-running {!r} (file {!s})".format(name, this))
+                continue
             if name not in self.by_name:
                 filename = os.path.join(self._args.checkdir, this)
                 self._logger.debug("Check {!r} (filename {!r}) not found in jobs".format(name, filename))
@@ -1019,6 +1025,7 @@ def parse_args(defaults: Mapping[str, Any]) -> Arguments:
 
     parser_ls.add_argument("names", nargs="*", default=[], help="Names of jobs to include", metavar="NAME")
     parser_check.add_argument("names", nargs="*", default=[], help="Names of jobs to include", metavar="NAME")
+    parser_check.add_argument("--exclude", dest="exclude", nargs="+", default=[], help="Names of jobs to exclude", metavar="NAME")
     parser_lastlog.add_argument("names", nargs="*", default=[], help="Names of jobs to include", metavar="NAME")
     parser_lastfaillog.add_argument("names", nargs="*", default=[], help="Names of jobs to include", metavar="NAME")
 

--- a/src/tests/test_mode_check.py
+++ b/src/tests/test_mode_check.py
@@ -1,0 +1,57 @@
+"""
+Baseline tests derived from real job statuses observed on a host running
+scriptherder-wrapped cronjobs.
+"""
+
+import sys
+import time
+import logging
+import unittest
+
+from scriptherder import Job, Check
+
+logging.basicConfig(level=logging.DEBUG, stream=sys.stderr,
+                    format='%(asctime)s: %(threadName)s %(levelname)s %(message)s')
+logger = logging.getLogger('unittest')
+
+
+def _make_job(name, age_seconds, exit_status, check_status=None):
+    """Return a Job constructed from a data dict (no actual execution)."""
+    now = time.time()
+    data = {
+        'cmd': ['/usr/local/bin/job.sh'],
+        'exit_status': exit_status,
+        'name': name,
+        'pid': 12345,
+        'start_time': now - age_seconds - 10,
+        'end_time': now - age_seconds,
+        'output_size': 0,
+        'version': 2,
+    }
+    if check_status is not None:
+        data['check_status'] = check_status
+        data['check_reason'] = 'exit=0'
+    return Job(name, data=data)
+
+
+def _check(ok_str, warn_str):
+    return Check(ok_str=ok_str, warning_str=warn_str,
+                 filename='unit_testing', logger=logger,
+                 runtime_mode=False)
+
+
+class TestModeCheck(unittest.TestCase):
+
+    def test_cosmos_ok(self):
+        """cosmos ran 9 minutes ago with check_status=OK → OK"""
+        job = _make_job('cosmos', age_seconds=9 * 60, exit_status=0, check_status='OK')
+        job.check(_check('exit_status=0, max_age=90m',
+                         'exit_status=0, max_age=24h'), logger)
+        self.assertTrue(job.is_ok())
+
+    def test_backup_daily_ok(self):
+        """backup_daily ran 30 hours ago (well within 50h ok threshold) with check_status=OK → OK"""
+        job = _make_job('backup_daily', age_seconds=30 * 3600, exit_status=0, check_status='OK')
+        job.check(_check('exit_status=0, max_age=50h',
+                         'exit_status=0, max_age=72h'), logger)
+        self.assertTrue(job.is_ok())


### PR DESCRIPTION
add --exclude to check to be able to exclude jobs already checked (like cosmos) from catch-all check